### PR TITLE
allow setting cumulus-message-adapter directory with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add the `CUMULUS_MESSAGE_ADAPTER_DIR` environment variable to set the path where cumulus-message-adapter is located
+
 ## [v1.0.0] - 2018-03-07
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
 - Add the `CUMULUS_MESSAGE_ADAPTER_DIR` environment variable to set the path where cumulus-message-adapter is located
 
 ## [v1.0.0] - 2018-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## [v1.0.1] - 2018-03-08
 ### Added
 
 - Add the `CUMULUS_MESSAGE_ADAPTER_DIR` environment variable to set the path where cumulus-message-adapter is located
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release
 
-[Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/cumulus-nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.1...HEAD
+[v1.0.1]: https://github.com/cumulus-nasa/cumulus-cumulus-message-adapter-js/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/cumulus-nasa/cumulus-message-adapter-js/tree/v1.0.0

--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ NodeTest:
   useMessageAdapter: true
 ```
 
+## Environment variables
+
+There are two environment variables that can be used with this library. Both are rarely needed for most use cases:
+
+- `CUMULUS_MESSAGE_ADAPTER_DISABLED=true`
+  - Defaults to false. This env var disables Cumulus Message Adapter. This can be used to turn off the message adapter for tasks that adapt the message on their own, or for testing.
+- `CUMULUS_MESSAGE_ADAPTER_DIR`
+  - The default directory for Cumulus Message Adapter is the root directory of the lambda function. There are rare cases (see [cumulus-ecs-task](https://github.com/cumulus-nasa/cumulus-ecs-task) for an example) where the adapter directory will be in a different location. This env var is unlikely to be useful for tasks, only for libraries that are working with Cumulus tasks at a higher level.
+
 ## Development
 
 ### Running Tests

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ class CumulusMessageAdapterExecutionError extends Error {
  */
 function callCumulusMessageAdapter(command, input) {
   return new Promise((resolve, reject) => {
-    const cumulusMessageAdapter = cp.spawn('python', ['./cumulus-message-adapter', command]);
+    const adapterDir = process.env.CUMULUS_MESSAGE_ADAPTER_DIR || './cumulus-message-adapter';
+    const cumulusMessageAdapter = cp.spawn('python', [adapterDir, command]);
 
     // Collect STDOUT
     let cumulusMessageAdapterStdout = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-message-adapter-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cumulus message adapter",
   "main": "index.js",
   "scripts": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "require-jsdoc": "off"
+  }
+}

--- a/test/alternate-dir/cumulus-message-adapter/__main__.py
+++ b/test/alternate-dir/cumulus-message-adapter/__main__.py
@@ -1,0 +1,4 @@
+import sys
+
+for line in sys.stdin:
+    sys.stdout.write(line)

--- a/test/test-index-with-dir-env.js
+++ b/test/test-index-with-dir-env.js
@@ -1,0 +1,53 @@
+/* eslint-disable require-jsdoc */
+
+const path = require('path');
+
+const test = require('ava').serial;
+const cumulusMessageAdapter = require('../index');
+
+test.cb('CUMULUS_MESSAGE_ADAPTER_DIR sets the location of the message adapter', (t) => {
+  const dir = path.join(__dirname, 'alternate-dir', 'cumulus-message-adapter');
+  process.env.CUMULUS_MESSAGE_ADAPTER_DIR = dir;
+
+  const businessLogicOutput = 42;
+  const businessLogic = () => businessLogicOutput;
+
+  const inputEvent = { a: 1 };
+
+  const expectedOutput = {
+    event: {
+      event: inputEvent,
+      schemas: null
+    },
+    handler_response: businessLogicOutput,
+    message_config: null,
+    schemas: null
+  };
+
+  function callback(err, data) {
+    t.is(err, null);
+    t.deepEqual(data, expectedOutput);
+    t.end();
+  }
+
+  return cumulusMessageAdapter.runCumulusTask(businessLogic, inputEvent, {}, callback);
+});
+
+test.cb('callback returns error if CUMULUS_MESSAGE_ADAPTER_DIR is incorrect', (t) => {
+  const dir = path.join(__dirname, 'wrong-dir', 'cumulus-message-adapter');
+  process.env.CUMULUS_MESSAGE_ADAPTER_DIR = dir;
+
+  const businessLogicOutput = 42;
+  const businessLogic = () => businessLogicOutput;
+
+  const inputEvent = { a: 1 };
+
+  function callback(err, data) {
+    t.is(typeof err, 'object');
+    t.is(err.name, 'CumulusMessageAdapterExecutionError');
+    t.is(data, undefined);
+    t.end();
+  }
+
+  cumulusMessageAdapter.runCumulusTask(businessLogic, inputEvent, {}, callback);
+});

--- a/test/test-index-with-dir-env.js
+++ b/test/test-index-with-dir-env.js
@@ -1,5 +1,3 @@
-/* eslint-disable require-jsdoc */
-
 const path = require('path');
 
 const test = require('ava').serial;

--- a/test/test-index-with-env.js
+++ b/test/test-index-with-env.js
@@ -1,5 +1,3 @@
-/* eslint-disable require-jsdoc */
-
 const test = require('ava');
 const cumulusMessageAdapter = require('../index');
 

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,5 +1,3 @@
-/* eslint-disable require-jsdoc */
-
 const test = require('ava');
 const cumulusMessageAdapter = require('../index');
 


### PR DESCRIPTION
This is a dependency for merging [this PR](https://github.com/cumulus-nasa/cumulus-ecs-task/pull/1) and releasing the first version of [cumulus-ecs-task](https://github.com/cumulus-nasa/cumulus-ecs-task).

This lets us set the directory where cumulus-message-adapter can be found in unusual cases where it isn't the root working directory, like in the case of cumulus-ecs-task.

This PR adds tests and updates the changelog and readme.